### PR TITLE
Updates on Code Cleanup tasks

### DIFF
--- a/Excel/reader.php
+++ b/Excel/reader.php
@@ -258,7 +258,9 @@ class Spreadsheet_Excel_Reader
      */
     function Spreadsheet_Excel_Reader()
     {
-        $this->_ole =& new OLERead();
+        //$this->_ole =& new OLERead();
+        //Above code is deprecated for later version of PHP
+        $this->_ole = new OLERead();
         $this->setUTFEncoder('iconv');
     }
 

--- a/WPOER.komodoproject
+++ b/WPOER.komodoproject
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Komodo Project File - DO NOT EDIT -->
+<project id="2141d48e-369c-4cf7-97ff-94766bf01263" kpf_version="5" name="WPOER.komodoproject">
+</project>

--- a/ajax/ajax.php
+++ b/ajax/ajax.php
@@ -9,7 +9,7 @@ if($_REQUEST["task"] == 'get_standards')
 	extract($_POST);
 
 	$standard_id = 'core_standards-'.$standard_id;
-	$results = $wpdb->get_results("SELECT * from oer_sub_standards where parent_id ='$standard_id'",ARRAY_A);
+	$results = $wpdb->get_results("SELECT * from " . $wpdb->prefix. "sub_standards where parent_id ='$standard_id'",ARRAY_A);
 	if(!empty($results))
 	{
 		get_child($standard_id);
@@ -43,7 +43,7 @@ if($_REQUEST["task"] == 'get_standards')
 function get_child($id)
 {
 	global $wpdb;
-	$results = $wpdb->get_results("SELECT * from oer_sub_standards where parent_id ='$id'",ARRAY_A);
+	$results = $wpdb->get_results("SELECT * from " . $wpdb->prefix. "sub_standards where parent_id ='$id'",ARRAY_A);
 	if(!empty($results))
 	{
 		echo "<ul>";
@@ -69,7 +69,7 @@ function get_child($id)
 function get_thrchild($id )
 {
 	global $wpdb;
-	$results = $wpdb->get_results("SELECT * from oer_standard_notation where parent_id ='$id'",ARRAY_A);
+	$results = $wpdb->get_results("SELECT * from " . $wpdb->prefix. "standard_notation where parent_id ='$id'",ARRAY_A);
 	if(!empty($results))
 	{
 		echo "<ul>";
@@ -102,7 +102,7 @@ function get_thrchild($id )
 function child_exist($id)
 {
 	global $wpdb;
-	$results = $wpdb->get_results("SELECT * from oer_standard_notation where parent_id ='$id'",ARRAY_A);
+	$results = $wpdb->get_results("SELECT * from " . $wpdb->prefix. "standard_notation where parent_id ='$id'",ARRAY_A);
 	return $results;
 }
 ?>

--- a/includes/assign_categories.php
+++ b/includes/assign_categories.php
@@ -7,13 +7,13 @@ function user_pages($ids)
 	{
 		foreach($ids as $id)
 		{
-			$pages = $wpdb->get_results("select page_id from oer_category_page where resource_category_id = '$id'",ARRAY_A);
+			$pages = $wpdb->get_results("select page_id from " . $wpdb->prefix. "category_page where resource_category_id = '$id'",ARRAY_A);
 			$page_id[] = $pages[0]['page_id'];
 		}
 	}
 	else
 	{
-		$pages = $wpdb->get_results("select page_id from oer_category_page where resource_category_id = '$id'",ARRAY_A);
+		$pages = $wpdb->get_results("select page_id from " . $wpdb->prefix. "category_page where resource_category_id = '$id'",ARRAY_A);
 		$page_id = $pages[0]['page_id'];
 	}
 	return $page_id;

--- a/includes/categories-importer.php
+++ b/includes/categories-importer.php
@@ -76,7 +76,7 @@ if(isset($_POST['bulk_imprt']))
 							$page_ids[$k] = $newvalue;
 							update_post_meta( $newvalue, '_wp_page_template', get_option("oer_category_template") );
 
-							$wpdb->get_results("insert into oer_category_page values('','$cat_parentid','$rsc_parentid','$newvalue','$title')");
+							$wpdb->get_results("insert into " . $wpdb->prefix. "category_page values('','$cat_parentid','$rsc_parentid','$newvalue','$title')");
 							break;
 						}
 						else

--- a/includes/init.php
+++ b/includes/init.php
@@ -200,7 +200,9 @@ function create_resource_taxonomies() {
 add_action('save_post', 'oer_save_customfields');
 function oer_save_customfields()
 {
-	global $post;
+    global $post;
+    //Check first if $post is not empty
+    if ($post) {
 	if($post->post_type == 'resource')
 	{
 		if(isset($_POST['oer_resourceurl']))
@@ -442,7 +444,7 @@ function oer_save_customfields()
 		}//Create Screeenshot
 
 	}
-
+    }
 }
 
 function getScreenshotFile($url)

--- a/includes/oer-functions.php
+++ b/includes/oer-functions.php
@@ -2,7 +2,7 @@
 function get_sub_standard($id, $oer_standard)
 {
 	global $wpdb;
-	$results = $wpdb->get_results("SELECT * from oer_sub_standards where parent_id ='$id'",ARRAY_A);
+	$results = $wpdb->get_results("SELECT * from " . $wpdb->prefix. "sub_standards where parent_id ='$id'",ARRAY_A);
 	if(!empty($oer_standard))
 	{
 		$stndrd_arr = explode(",",$oer_standard);
@@ -49,7 +49,7 @@ function get_sub_standard($id, $oer_standard)
 function get_standard_notation($id, $oer_standard)
 {
 	global $wpdb;
-	$results = $wpdb->get_results("SELECT * from oer_standard_notation where parent_id ='$id'",ARRAY_A);
+	$results = $wpdb->get_results("SELECT * from " . $wpdb->prefix. "standard_notation where parent_id ='$id'",ARRAY_A);
 
 	if(!empty($oer_standard))
 	{
@@ -103,7 +103,7 @@ function get_standard_notation($id, $oer_standard)
 function check_child($id)
 {
 	global $wpdb;
-	$results = $wpdb->get_results("SELECT * from oer_standard_notation where parent_id ='$id'",ARRAY_A);
+	$results = $wpdb->get_results("SELECT * from " . $wpdb->prefix. "standard_notation where parent_id ='$id'",ARRAY_A);
 	return $results;
 }
 ?>

--- a/includes/resource_metafields.php
+++ b/includes/resource_metafields.php
@@ -176,7 +176,7 @@ global $wpdb;
 			 <div class="oer_fld">
 				<div class="oer_lstofstandrd ">
 				 	  <?php
-							$results = $wpdb->get_results("SELECT * from oer_core_standards",ARRAY_A);
+							$results = $wpdb->get_results("SELECT * from " . $wpdb->prefix. "core_standards",ARRAY_A);
 							foreach($results as $result)
 							{
 								$value = 'core_standards-'.$result['id'];

--- a/includes/resources-importer.php
+++ b/includes/resources-importer.php
@@ -202,14 +202,14 @@ if(isset($_POST['resrc_imprt']))
 				$gt_oer_standard = '';
 				for($l = 0; $l < count($oer_standard); $l++)
 				{
-					$results = $wpdb->get_row("SELECT * from oer_standard_notation where standard_notation ='$oer_standard[$l]'",ARRAY_A);
+					$results = $wpdb->get_row("SELECT * from " . $wpdb->prefix. "standard_notation where standard_notation ='$oer_standard[$l]'",ARRAY_A);
 					if(!empty($results))
 					{
 						$gt_oer_standard .= "oer_standard_notation-".$results['id'].",";
 						$table = explode("-", $results['parent_id']);
 						if(!empty($table))
 						{
-							$stndrd_algn = $wpdb->get_row("SELECT * from oer_$table[0] where id ='$table[1]'",ARRAY_A);
+							$stndrd_algn = $wpdb->get_row("SELECT * from  " . $wpdb->prefix. $table[0] . " where id ='$table[1]'",ARRAY_A);
 							if($stndrd_algn['parent_id'])
 							{
 								fetch_stndrd($stndrd_algn['parent_id'], $post_id);
@@ -342,7 +342,7 @@ function fetch_stndrd($pId, $postid)
 {
 	global $wpdb;
 	$table = explode("-", $pId);
-	$stndrd_algn = $wpdb->get_row("SELECT * from oer_$table[0] where id ='$table[1]'",ARRAY_A);
+	$stndrd_algn = $wpdb->get_row("SELECT * from  " . $wpdb->prefix. $table[0] . " where id ='$table[1]'",ARRAY_A);
 
 	if(preg_match("/core_standards/", $table[0]))
 	{

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -19,7 +19,8 @@
 	$oer_python_path 	= get_option("oer_python_path");
 	$oer_python_install = get_option("oer_python_install");
 
-	$options .= "<option value=''>--- Select Template ---</option>";
+	// Removed the concatenation shorthand as the variable didn't exist above this code yet
+	$options = "<option value=''>--- Select Template ---</option>";
 	foreach ( $templates as $template_name => $template_filename )
 	{
 		if($slct_template == $template_filename)

--- a/includes/standards-importer.php
+++ b/includes/standards-importer.php
@@ -82,10 +82,10 @@ if(isset($_POST['standards_import']))
 		{
 			$url = $cskey;
 			$title = $csdata['title'];
-			$results = $wpdb->get_results("SELECT id from oer_core_standards where standard_name = '$title'");
+			$results = $wpdb->get_results("SELECT id from " . $wpdb->prefix. "core_standards where standard_name = '$title'");
 			if(empty($results))
 			{
-				$wpdb->get_results('INSERT INTO oer_core_standards values("","'.$title.'", "'.$url.'")');
+				$wpdb->get_results('INSERT INTO " . $wpdb->prefix. "core_standards values("","'.$title.'", "'.$url.'")');
 			}
 		}
 		// Get Core Standard
@@ -98,24 +98,24 @@ if(isset($_POST['standards_import']))
 			$title = $data['title'];
 			$parent = '';
 
-			$rsltset = $wpdb->get_results("select id from oer_core_standards where standard_url='$ischild'");
+			$rsltset = $wpdb->get_results("select id from " . $wpdb->prefix. "core_standards where standard_url='$ischild'");
 			if(!empty($rsltset))
 			{
 				$parent = "core_standards-".$rsltset[0]->id;
 			}
 			else
 			{
-				$rsltset_sec = $wpdb->get_results("select id from oer_sub_standards where url='$ischild'");
+				$rsltset_sec = $wpdb->get_results("select id from " . $wpdb->prefix. "sub_standards where url='$ischild'");
 				if(!empty($rsltset_sec))
 				{
 					$parent = 'sub_standards-'.$rsltset_sec[0]->id;
 				}
 			}
 
-			$res = $wpdb->get_results("SELECT id from oer_sub_standards where parent_id = '$parent' && url = '$url'");
+			$res = $wpdb->get_results("SELECT id from " . $wpdb->prefix. "sub_standards where parent_id = '$parent' && url = '$url'");
 			if(empty($res))
 			{
-				$wpdb->get_results('INSERT INTO oer_sub_standards values("", "'.$parent.'", "'.$title.'", "'.$url.'")');
+				$wpdb->get_results('INSERT INTO ' . $wpdb->prefix. 'sub_standards values("", "'.$parent.'", "'.$title.'", "'.$url.'")');
 			}
 		}
 		// Get Sub Standard
@@ -129,26 +129,26 @@ if(isset($_POST['standards_import']))
 			$description = $st_data['description'];
 			$parent = '';
 
-			$rsltset = $wpdb->get_results("select id from oer_sub_standards where url='$ischild'");
+			$rsltset = $wpdb->get_results("select id from " . $wpdb->prefix. "sub_standards where url='$ischild'");
 			if(!empty($rsltset))
 			{
 				$parent = 'sub_standards-'.$rsltset[0]->id;
 			}
 			else
 			{
-				$rsltset_sec = $wpdb->get_results("select id from oer_standard_notation where url='$ischild'");
+				$rsltset_sec = $wpdb->get_results("select id from " . $wpdb->prefix. "standard_notation where url='$ischild'");
 				if(!empty($rsltset_sec))
 				{
 					$parent = 'standard_notation-'.$rsltset_sec[0]->id;
 				}
 			}
 
-			$res = $wpdb->get_results("SELECT id from oer_standard_notation where standard_notation = '$notation' && parent_id = '$parent' && url = '$url'");
+			$res = $wpdb->get_results("SELECT id from " . $wpdb->prefix. "standard_notation where standard_notation = '$notation' && parent_id = '$parent' && url = '$url'");
 			if(empty($res))
 			{
 				//$description = preg_replace("/[^a-zA-Z0-9]+/", " ", html_entity_decode($description))
 				$description = mysql_real_escape_string($description);
-				$wpdb->get_results('INSERT INTO oer_standard_notation values("", "'.$parent.'", "'.$notation.'", "'.$description.'", "", "'.$url.'")');
+				$wpdb->get_results('INSERT INTO " . $wpdb->prefix. "standard_notation values("", "'.$parent.'", "'.$notation.'", "'.$description.'", "", "'.$url.'")');
 			}
 		}
 		// Get Standard Notation

--- a/open-educational-resources.php
+++ b/open-educational-resources.php
@@ -37,62 +37,66 @@ register_activation_hook(__FILE__, 'create_csv_import_table');
 function create_csv_import_table()
 {
 	global $wpdb;
-	$table_name = "oer_core_standards";
+	//Change hard-coded table prefix to $wpdb->prefix
+	$table_name = $wpdb->prefix . "core_standards";
 	if($wpdb->get_var("show tables like '$table_name'") != $table_name)
-    {
-      $sql = "CREATE TABLE IF NOT EXISTS $table_name (
- 			id int(20) NOT NULL AUTO_INCREMENT,
-  			standard_name varchar(255) NOT NULL,
-			standard_url varchar(255) NOT NULL,
-			PRIMARY KEY (id)
-			);";
-      require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-      dbDelta($sql);
-   }
+	{
+	  $sql = "CREATE TABLE IF NOT EXISTS $table_name (
+			    id int(20) NOT NULL AUTO_INCREMENT,
+			    standard_name varchar(255) NOT NULL,
+			    standard_url varchar(255) NOT NULL,
+			    PRIMARY KEY (id)
+			    );";
+	  require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+	  dbDelta($sql);
+       }
 
-    $table_name = "oer_sub_standards";
+	//Change hard-coded table prefix to $wpdb->prefix
+	$table_name = $wpdb->prefix . "sub_standards";
 	if($wpdb->get_var("show tables like '$table_name'") != $table_name)
-    {
-      $sql = "CREATE TABLE IF NOT EXISTS $table_name (
- 			id int(20) NOT NULL AUTO_INCREMENT,
-  			parent_id varchar(255) NOT NULL,
-			standard_title varchar(255) NOT NULL,
-			url varchar(255) NOT NULL,
-			PRIMARY KEY (id)
-			);";
-      require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-      dbDelta($sql);
-   }
+	{
+	  $sql = "CREATE TABLE IF NOT EXISTS $table_name (
+			    id int(20) NOT NULL AUTO_INCREMENT,
+			    parent_id varchar(255) NOT NULL,
+			    standard_title varchar(255) NOT NULL,
+			    url varchar(255) NOT NULL,
+			    PRIMARY KEY (id)
+			    );";
+	  require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+	  dbDelta($sql);
+	}
 
-   $table_name = "oer_standard_notation";
+	//Change hard-coded table prefix to $wpdb->prefix
+	$table_name = $wpdb->prefix . "standard_notation";
 	if($wpdb->get_var("show tables like '$table_name'") != $table_name)
-    {
-      $sql = "CREATE TABLE IF NOT EXISTS $table_name (
- 			id int(20) NOT NULL AUTO_INCREMENT,
-  			parent_id varchar(255) NOT NULL,
-			standard_notation varchar(255) NOT NULL,
-			description varchar(255) NOT NULL,
-			comment varchar(255) NOT NULL,
-			url varchar(255) NOT NULL,
-			PRIMARY KEY (id)
-			);";
-      require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-      dbDelta($sql);
-   }
+	 {
+	   $sql = "CREATE TABLE IF NOT EXISTS $table_name (
+			     id int(20) NOT NULL AUTO_INCREMENT,
+			     parent_id varchar(255) NOT NULL,
+			     standard_notation varchar(255) NOT NULL,
+			     description varchar(255) NOT NULL,
+			     comment varchar(255) NOT NULL,
+			     url varchar(255) NOT NULL,
+			     PRIMARY KEY (id)
+			     );";
+	   require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+	   dbDelta($sql);
+	}
 
-   $table_name = "oer_category_page";
+	//Change hard-coded table prefix to $wpdb->prefix
+	$table_name = $wpdb->prefix . "category_page";
 	if($wpdb->get_var("show tables like '$table_name'") != $table_name)
-    {
-      $sql = "CREATE TABLE IF NOT EXISTS $table_name (
- 			id int(20) NOT NULL AUTO_INCREMENT,
-  			blog_category_id varchar(255) NOT NULL,
-			resource_category_id varchar(255) NOT NULL,
-			page_id varchar(255) NOT NULL,
-			page_name varchar(255) NOT NULL,
-			PRIMARY KEY (id));";
-      require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-      dbDelta($sql);
-   }
+	{
+	   $sql = "CREATE TABLE IF NOT EXISTS $table_name (
+			     id int(20) NOT NULL AUTO_INCREMENT,
+			     blog_category_id varchar(255) NOT NULL,
+			     resource_category_id varchar(255) NOT NULL,
+			     page_id varchar(255) NOT NULL,
+			     page_name varchar(255) NOT NULL,
+			     PRIMARY KEY (id));";
+	   require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+	   dbDelta($sql);
+	}
 
    //CreatePage('Resource Form','[oer_resource_form]','resource_form'); // creating page
    //create_template();
@@ -141,6 +145,20 @@ function CreatePage($title,$content,$slug)
 	}
 ob_clean();
 }
+
+/** Add Settings Link on Plugins page **/
+add_filter( 'plugin_action_links' , 'add_oer_settings_link' , 10 , 2 );
+/** Add Settings Link function **/
+function add_oer_settings_link( $links, $file ){
+	if ( $file == plugin_basename(dirname(__FILE__).'/open-educational-resources.php') ) {
+		/** Insert settings link **/
+		$link = "<a href='edit.php?post_type=resource&page=oer_settings'>".__('Settings','oer')."</a>";
+		array_unshift($links, $link);
+		/** End of Insert settings link **/
+	}
+	return $links;
+}
+/** End of Add Settings Link on Plugins page **/
 
 /* Adding Auto Update Functionality*/
 


### PR DESCRIPTION
“Settings” link on the plugin page. There’s already a view for it, but no link on Plugins page. - done
use WP prefix for all tables ($wpdb->prefix) - done
Turn debug on, cleanup any problems (for example, warnings about unset variables) - on-going
